### PR TITLE
🐋👌Add VC Redistributable to base images for python package compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Repo to build and publish windows docker images with uv and multiple python vers
 
 Additionally the latest (2015-2022) Visual Studio Redistributable has been added to the images.
 
-The repo builds 2 types of images: `server` and `servercore` with as basis respectively:
+The repo builds 2 images: `server` and `servercore` with the respective base images:
 
-- mcr.microsoft.com/windows/server:ltsc2022
-- mcr.microsoft.com/windows/servercore:ltsc2022
+- `mcr.microsoft.com/windows/server:ltsc2022`
+- `mcr.microsoft.com/windows/servercore:ltsc2022`
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
 # uv-windows-docker
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-Repo to build and publish windows docker images with uv and multiple python versions installed
 
-Repo to build and publish windows docker images with uv and multiple python versions installed.
-
-Additionally the latest (2015-2022) Visual Studio Redistributable has been added to the images.
-
-The repo builds 2 images: `server` and `servercore` with the respective base images:
-
-- `mcr.microsoft.com/windows/server:ltsc2022`
-- `mcr.microsoft.com/windows/servercore:ltsc2022`
+This repository builds and publishes Windows Docker images with uv, multiple Python versions, the latest Visual Studio Redistributable (2015–2022), and includes two images—`server` and `servercore`—based on `mcr.microsoft.com/windows/server:ltsc2022` and `mcr.microsoft.com/windows/servercore:ltsc2022`, respectively.
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 Repo to build and publish windows docker images with uv and multiple python versions installed
 
+Repo to build and publish windows docker images with uv and multiple python versions installed.
+
+Additionally the latest (2015-2022) Visual Studio Redistributable has been added to the images.
+
+The repo builds 2 types of images: `server` and `servercore` with as basis respectively:
+
+- mcr.microsoft.com/windows/server:ltsc2022
+- mcr.microsoft.com/windows/servercore:ltsc2022
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -15,14 +15,14 @@ LABEL org.opencontainers.image.source=https://github.com/s-weigand/uv-windows-do
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
+  -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
 RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
     $installerPath='C:\vc_redist.x64.exe'; `
     (New-Object System.Net.WebClient).DownloadFile($vcRedistUrl, $installerPath); `
     Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
     Remove-Item -Path $installerPath -Force
-
-RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
-  -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
 RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -2,32 +2,29 @@
 
 FROM mcr.microsoft.com/windows/server:ltsc2022
 
+ARG UV_VERSION
+ARG PYTHON_VERSIONS="3.9 3.10 3.11 3.12 3.13"
+
 # OCI labels for metadata
 LABEL org.opencontainers.image.title="Windows Server LTSC 2022 Image pre-installed with uv and VC Redist"
 LABEL org.opencontainers.image.description="A Windows Server image with the uv python package and project manager from astral  installed, Python version 3.9-3.13 pre-installed, and including the Visual C++ Redistributable."
-LABEL org.opencontainers.image.version="0.0.2"
-# LABEL org.opencontainers.image.authors="Sebastian Weigand <s.weigand.phy@gmail.com>"
+LABEL org.opencontainers.image.version="${UV_VERSION}"
 LABEL org.opencontainers.image.url="https://github.com/s-weigand/uv-windows-docker"
 LABEL org.opencontainers.image.documentation="https://github.com/s-weigand/uv-windows-docker/blob/main/README.md"
 LABEL org.opencontainers.image.source=https://github.com/s-weigand/uv-windows-docker
-LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
     $installerPath='C:\vc_redist.x64.exe'; `
-    Invoke-WebRequest -Uri $vcRedistUrl -OutFile $installerPath -UseBasicParsing; `
+    (New-Object System.Net.WebClient).DownloadFile($vcRedistUrl, $installerPath); `
     Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
     Remove-Item -Path $installerPath -Force
 
 RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
   -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
-ARG UV_VERSION
-
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
 RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path
-
-ARG PYTHON_VERSIONS="3.9 3.10 3.11 3.12 3.13"
 
 RUN uv python install $env:PYTHON_VERSIONS.split(' ')

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -5,6 +5,12 @@ FROM mcr.microsoft.com/windows/server:ltsc2022
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
+    $installerPath='C:\vc_redist.x64.exe'; `
+    Invoke-WebRequest -Uri $vcRedistUrl -OutFile $installerPath -UseBasicParsing; `
+    Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
+    Remove-Item -Path $installerPath -Force
+
 RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
   -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -2,6 +2,15 @@
 
 FROM mcr.microsoft.com/windows/server:ltsc2022
 
+# OCI labels for metadata
+LABEL org.opencontainers.image.title="Windows Server LTSC 2022 Image pre-installed with uv and VC Redist"
+LABEL org.opencontainers.image.description="A Windows Server image with the uv python package and project manager from astral  installed, Python version 3.9-3.13 pre-installed, and including the Visual C++ Redistributable."
+LABEL org.opencontainers.image.version="0.0.2"
+# LABEL org.opencontainers.image.authors="Sebastian Weigand <s.weigand.phy@gmail.com>"
+LABEL org.opencontainers.image.url="https://github.com/s-weigand/uv-windows-docker"
+LABEL org.opencontainers.image.documentation="https://github.com/s-weigand/uv-windows-docker/blob/main/README.md"
+LABEL org.opencontainers.image.source=https://github.com/s-weigand/uv-windows-docker
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/docker/Dockerfile.servercore
+++ b/docker/Dockerfile.servercore
@@ -2,32 +2,29 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
+ARG UV_VERSION
+ARG PYTHON_VERSIONS="3.9 3.10 3.11 3.12 3.13"
+
 # OCI labels for metadata
 LABEL org.opencontainers.image.title="Windows Server Core LTSC 2022 Image pre-installed with uv and VC Redist"
 LABEL org.opencontainers.image.description="A Windows Server Core image with the uv python package and project manager from astral  installed, Python version 3.9-3.13 pre-installed, and including the Visual C++ Redistributable."
-LABEL org.opencontainers.image.version="0.0.2"
-# LABEL org.opencontainers.image.authors="Sebastian Weigand <s.weigand.phy@gmail.com>"
+LABEL org.opencontainers.image.version="${UV_VERSION}"
 LABEL org.opencontainers.image.url="https://github.com/s-weigand/uv-windows-docker"
 LABEL org.opencontainers.image.documentation="https://github.com/s-weigand/uv-windows-docker/blob/main/README.md"
 LABEL org.opencontainers.image.source=https://github.com/s-weigand/uv-windows-docker
-LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
     $installerPath='C:\vc_redist.x64.exe'; `
-    Invoke-WebRequest -Uri $vcRedistUrl -OutFile $installerPath -UseBasicParsing; `
+    (New-Object System.Net.WebClient).DownloadFile($vcRedistUrl, $installerPath); `
     Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
     Remove-Item -Path $installerPath -Force
 
 RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
   -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
-ARG UV_VERSION
-
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
 RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path
-
-ARG PYTHON_VERSIONS="3.9 3.10 3.11 3.12 3.13"
 
 RUN uv python install $env:PYTHON_VERSIONS.split(' ')

--- a/docker/Dockerfile.servercore
+++ b/docker/Dockerfile.servercore
@@ -2,6 +2,15 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
+# OCI labels for metadata
+LABEL org.opencontainers.image.title="Windows Server Core LTSC 2022 Image pre-installed with uv and VC Redist"
+LABEL org.opencontainers.image.description="A Windows Server Core image with the uv python package and project manager from astral  installed, Python version 3.9-3.13 pre-installed, and including the Visual C++ Redistributable."
+LABEL org.opencontainers.image.version="0.0.2"
+# LABEL org.opencontainers.image.authors="Sebastian Weigand <s.weigand.phy@gmail.com>"
+LABEL org.opencontainers.image.url="https://github.com/s-weigand/uv-windows-docker"
+LABEL org.opencontainers.image.documentation="https://github.com/s-weigand/uv-windows-docker/blob/main/README.md"
+LABEL org.opencontainers.image.source=https://github.com/s-weigand/uv-windows-docker
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/docker/Dockerfile.servercore
+++ b/docker/Dockerfile.servercore
@@ -5,6 +5,12 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
+    $installerPath='C:\vc_redist.x64.exe'; `
+    Invoke-WebRequest -Uri $vcRedistUrl -OutFile $installerPath -UseBasicParsing; `
+    Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
+    Remove-Item -Path $installerPath -Force
+
 RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
   -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 

--- a/docker/Dockerfile.servercore
+++ b/docker/Dockerfile.servercore
@@ -15,14 +15,14 @@ LABEL org.opencontainers.image.source=https://github.com/s-weigand/uv-windows-do
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
+RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
+  -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
+  RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
     $installerPath='C:\vc_redist.x64.exe'; `
     (New-Object System.Net.WebClient).DownloadFile($vcRedistUrl, $installerPath); `
     Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
     Remove-Item -Path $installerPath -Force
-
-RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
-  -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
 RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path


### PR DESCRIPTION
Update the Dockerfiles to bundle the latest `vc_redist.x64.exe` into the images.

This is needed for certain python packages which implicitly assume these (redistributable) binaries are present on the system (see #1 for a reproducible example with `matplotlib`). 

Closes #1 