### PR TITLE
✨ Add git and git-lfs to images

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,7 @@ name: 🐋🚀 Publish images
 
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   build:
@@ -50,6 +51,7 @@ jobs:
           pushImage: false
 
       - name: 🚀🐋 Push image
+        if: github.event_name != 'pull_request'
         uses: mr-smithers-excellent/docker-build-push@v6
         with:
           image: uv-windows

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,11 +1,11 @@
-name: Publish container
+name: 🐋🚀 Publish images
 
 on:
   workflow_dispatch:
 
 jobs:
   build:
-    name: Publish ${{ matrix.name }}
+    name: 🐋🚀 Publish ${{ matrix.name }}
     permissions:
       contents: read
       packages: write
@@ -20,19 +20,39 @@ jobs:
             dockerfile: docker/Dockerfile.servercore
 
     steps:
-      - name: Checkout repository
+      - name: ⏬ Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set UV version
+      - name: ⚙️ Set UV version
         id: set-uv-version
         shell: bash
         run: echo "uv-version=$(cat .version)" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push image
+      - name: 👷🐋 Build image
+        id: test-base-image
         uses: mr-smithers-excellent/docker-build-push@v6
         with:
           image: uv-windows
-          tags: ${{ steps.set-uv-version.outputs.uv-version }}-${{ matrix.name }}
+          tags: ${{ steps.set-uv-version.outputs.uv-version }}-${{ matrix.name }}, latest-${{ matrix.name }}
+          registry: ghcr.io
+          dockerfile: ${{ matrix.dockerfile }}
+          buildArgs: UV_VERSION=${{ steps.set-uv-version.outputs.uv-version }}
+          pushImage: false
+
+      - name: 🧪🐋 Run test
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
+          image: test-runner-image
+          dockerfile: test/Dockerfile
+          registry: ghcr.io
+          buildArgs: |
+            BASE_IMAGE=${{ steps.test-base-image.outputs.imageFullName }}:latest-${{ matrix.name }}
+          pushImage: false
+
+      - name: 🚀🐋 Push image
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
+          image: uv-windows
           registry: ghcr.io
           dockerfile: ${{ matrix.dockerfile }}
           buildArgs: UV_VERSION=${{ steps.set-uv-version.outputs.uv-version }}

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,28 +1,23 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/server:ltsc2022
+FROM ghcr.io/s-weigand/winget-windows:v1.9.25200-ltsc2022
 
 ARG UV_VERSION
 ARG PYTHON_VERSIONS="3.9 3.10 3.11 3.12 3.13"
 
 # OCI labels for metadata
-LABEL org.opencontainers.image.title="Windows Server LTSC 2022 Image pre-installed with uv and VC Redist"
-LABEL org.opencontainers.image.description="A Windows Server image with the uv python package and project manager from astral  installed, Python version 3.9-3.13 pre-installed, and including the Visual C++ Redistributable."
+LABEL org.opencontainers.image.title="Windows Server LTSC 2022 Image pre-installed with uv, winget, git+LSF and VC Redist"
+LABEL org.opencontainers.image.description="A Windows Server image with the winget windows package manager, git+LSF, uv python package and project manager from astral installed, Python version 3.9-3.13 pre-installed, and including the Visual C++ Redistributable."
 LABEL org.opencontainers.image.version="${UV_VERSION}"
 LABEL org.opencontainers.image.url="https://github.com/s-weigand/uv-windows-docker"
 LABEL org.opencontainers.image.documentation="https://github.com/s-weigand/uv-windows-docker/blob/main/README.md"
 LABEL org.opencontainers.image.source=https://github.com/s-weigand/uv-windows-docker
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN winget.exe install --id "Git.Git" --exact --source winget `
+    --accept-source-agreements  --disable-interactivity --silent `
+    --accept-package-agreements --force
 
-RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
-  -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
-
-RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
-    $installerPath='C:\vc_redist.x64.exe'; `
-    (New-Object System.Net.WebClient).DownloadFile($vcRedistUrl, $installerPath); `
-    Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
-    Remove-Item -Path $installerPath -Force
+RUN git config --global init.defaultBranch main
 
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
 RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path

--- a/docker/Dockerfile.servercore
+++ b/docker/Dockerfile.servercore
@@ -18,11 +18,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
   -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
-  RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
-    $installerPath='C:\vc_redist.x64.exe'; `
-    (New-Object System.Net.WebClient).DownloadFile($vcRedistUrl, $installerPath); `
-    Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
-    Remove-Item -Path $installerPath -Force
+RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
+  $installerPath='C:\vc_redist.x64.exe'; `
+  (New-Object System.Net.WebClient).DownloadFile($vcRedistUrl, $installerPath); `
+  Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
+  Remove-Item -Path $installerPath -Force
 
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
 RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path

--- a/docker/Dockerfile.servercore
+++ b/docker/Dockerfile.servercore
@@ -24,6 +24,11 @@ RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
   Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
   Remove-Item -Path $installerPath -Force
 
+COPY --from=ghcr.io/s-weigand/mingit:ltsc2022 C:/git C:/git
+RUN [Environment]::SetEnvironmentVariable('PATH', [Environment]::GetEnvironmentVariable('PATH') + ';C:/git/cmd;C:/git/mingw64/bin;C:/git/usr/bin', 'Machine')
+RUN $env:Path = 'C:/git/cmd;C:/git/mingw64/bin;C:/git/usr/bin;' + $env:Path
+RUN git config --global init.defaultBranch main
+
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
 RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,8 @@
+# escape=`
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+COPY test .
+
+RUN uv run test.py

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,1 @@
+# test project

--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "test"
+version = "0.1.0"
+description = "Just a test for the images"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = ["git_install_test_distribution"]
+
+[tool.uv.sources]
+git_install_test_distribution = { git = "https://github.com/s-weigand/git-install-test-distribution" }

--- a/test/test.py
+++ b/test/test.py
@@ -1,7 +1,7 @@
 from git_install_test_distribution import __version__
 
 def main():
-    print("Was able to het version of git_install_test_distribution:",__version__)
+    print("Was able to get version of git_install_test_distribution:",__version__)
 
 
 if __name__ == "__main__":

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,8 @@
+from git_install_test_distribution import __version__
+
+def main():
+    print("Was able to het version of git_install_test_distribution:",__version__)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/uv.lock
+++ b/test/uv.lock
@@ -1,0 +1,18 @@
+version = 1
+requires-python = ">=3.13"
+
+[[package]]
+name = "git-install-test-distribution"
+version = "0.0.2"
+source = { git = "https://github.com/s-weigand/git-install-test-distribution#a7f7bf28dbe9bfceba1af8a259383e398a942ad0" }
+
+[[package]]
+name = "test"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "git-install-test-distribution" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "git-install-test-distribution", git = "https://github.com/s-weigand/git-install-test-distribution" }]


### PR DESCRIPTION
This change adds [git for windows](https://github.com/git-for-windows/git) and [git LFS](https://github.com/git-lfs/git-lfs) to the images.

Main reason is to support `uv` installation of packages that have direct dependencies on packages from `git` like in the added test example:
```toml
[tool.uv.sources]
git_install_test_distribution = { git = "https://github.com/s-weigand/git-install-test-distribution" }
```