### PR TITLE
🩹 Downgrade git from v2.47.1.windows.1 to v2.47.0.windows.2

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -21,6 +21,6 @@ RUN winget.exe install --id "Git.Git" --exact --source winget `
 RUN git config --global init.defaultBranch main
 
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
-RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path
+RUN $env:Path = 'C:/Users/ContainerAdministrator/.local/bin;' + $env:Path
 
 RUN uv python install $env:PYTHON_VERSIONS.split(' ')

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -15,7 +15,8 @@ LABEL org.opencontainers.image.source=https://github.com/s-weigand/uv-windows-do
 
 RUN winget.exe install --id "Git.Git" --exact --source winget `
     --accept-source-agreements  --disable-interactivity --silent `
-    --accept-package-agreements --force
+    --accept-package-agreements --force `
+    --version 2.47.0.2
 
 RUN git config --global init.defaultBranch main
 

--- a/docker/Dockerfile.servercore
+++ b/docker/Dockerfile.servercore
@@ -24,10 +24,27 @@ RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
   Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
   Remove-Item -Path $installerPath -Force
 
-COPY --from=ghcr.io/s-weigand/mingit:ltsc2022 C:/git C:/git
+RUN $downloadUrl='https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.2/MinGit-2.47.0.2-64-bit.zip'; `
+  $artifactPath='C:\mingit.zip'; `
+  (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $artifactPath); `
+  Expand-Archive -Path $artifactPath -DestinationPath C:/git; `
+  Remove-Item -Path $artifactPath -Force
+
+RUN $downloadUrl='https://github.com/git-lfs/git-lfs/releases/download/v3.6.0/git-lfs-windows-amd64-v3.6.0.zip'; `
+  $artifactPath='C:\git-lfs.zip'; `
+  $tmpExtractFolder='c:/tmp/git-lfs-3.6.0'; `
+  (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $artifactPath); `
+  Expand-Archive -Path $artifactPath -DestinationPath C:/tmp; `
+  Remove-Item -Path $artifactPath -Force; `
+  Copy-Item "$tmpExtractFolder/git-lfs.exe" 'c:/git/cmd/git-lfs.exe'; `
+  # Disable error about missing file, we can't view it in the container anyway due to the missing browser
+  New-Item 'C:/git/mingw64/share/doc/git-doc/git-lfs.html' -Force; `
+  Remove-Item -Path $tmpExtractFolder -Recurse -Force
+
 RUN [Environment]::SetEnvironmentVariable('PATH', [Environment]::GetEnvironmentVariable('PATH') + ';C:/git/cmd;C:/git/mingw64/bin;C:/git/usr/bin', 'Machine')
 RUN $env:Path = 'C:/git/cmd;C:/git/mingw64/bin;C:/git/usr/bin;' + $env:Path
 RUN git config --global init.defaultBranch main
+RUN git lfs install
 
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
 RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path

--- a/docker/Dockerfile.servercore
+++ b/docker/Dockerfile.servercore
@@ -19,19 +19,19 @@ RUN New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
   -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
 RUN $vcRedistUrl='https://aka.ms/vs/17/release/vc_redist.x64.exe'; `
-  $installerPath='C:\vc_redist.x64.exe'; `
+  $installerPath='C:/vc_redist.x64.exe'; `
   (New-Object System.Net.WebClient).DownloadFile($vcRedistUrl, $installerPath); `
   Start-Process -FilePath $installerPath -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
   Remove-Item -Path $installerPath -Force
 
 RUN $downloadUrl='https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.2/MinGit-2.47.0.2-64-bit.zip'; `
-  $artifactPath='C:\mingit.zip'; `
+  $artifactPath='C:/mingit.zip'; `
   (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $artifactPath); `
   Expand-Archive -Path $artifactPath -DestinationPath C:/git; `
   Remove-Item -Path $artifactPath -Force
 
 RUN $downloadUrl='https://github.com/git-lfs/git-lfs/releases/download/v3.6.0/git-lfs-windows-amd64-v3.6.0.zip'; `
-  $artifactPath='C:\git-lfs.zip'; `
+  $artifactPath='C:/git-lfs.zip'; `
   $tmpExtractFolder='c:/tmp/git-lfs-3.6.0'; `
   (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $artifactPath); `
   Expand-Archive -Path $artifactPath -DestinationPath C:/tmp; `
@@ -47,6 +47,6 @@ RUN git config --global init.defaultBranch main
 RUN git lfs install
 
 RUN irm https://astral.sh/uv/$env:UV_VERSION/install.ps1 | iex
-RUN $env:Path = 'C:\Users\ContainerAdministrator\.local\bin;' + $env:Path
+RUN $env:Path = 'C:/Users/ContainerAdministrator/.local/bin;' + $env:Path
 
 RUN uv python install $env:PYTHON_VERSIONS.split(' ')


### PR DESCRIPTION
The version of `curl` bundled with `mingit` `v2.47.1.windows.1` has a regression where the fallback to `~/_netrc` on windows is ignored and it only uses `~/.netrc`.
See https://github.com/git-for-windows/git/issues/5306
Since `git lfs` on windows only supports `~/_netrc` we decided to downgrade `mingit` to the latest working version (I tested that it works).

I created an [issue to remind us update `mingit`](https://github.com/s-weigand/uv-windows-docker/issues/11).

### Change summary

- [🩹 Pin git version in server image to 2.47.0.2](https://github.com/s-weigand/uv-windows-docker/pull/12/commits/87349093e0fa3a071e5e9c1fb6d5f7acc98acab7)
See the [package definition](https://github.com/microsoft/winget-pkgs/blob/master/manifests/g/Git/Git/2.47.0.2/Git.Git.installer.yaml) for how the git for windows version translates to the version on `winget`.
- [🩹 Manually install mingit and git lfs in servercore image](https://github.com/s-weigand/uv-windows-docker/pull/12/commits/f003c4be8a48b4c3a0256d0d38bfee2012fde9d5)
While the upstream image `ghcr.io/s-weigand/mingit:ltsc2022` [is now fixed](https://github.com/s-weigand/drone-ltsc2022-support/pkgs/container/mingit/335570085?tag=ltsc2022), the `ltsc2022` tag is a rolling tag, so having the install commands contained in the Dockerfile is more transparent and gives us more control.
- [🧹 Use / in paths instead of \ ](https://github.com/s-weigand/uv-windows-docker/pull/12/commits/a80666e576435ca17cbe27e259d74b3d51cac0e2) (`/` is a perfectly fine path separator on window, no need to use `\` in places where we don't have to)